### PR TITLE
[FIX] Display missing images in the organization overview

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -28,7 +28,7 @@ Want more details? Visit our [website](https://process-analytics.dev/).
 ### 🌈 Contributing to the ecosystem
 
 
-![Cheat sheet image](cheat_sheet.png)
+![An cheat sheet showing how to quickly contribute to the Process Analytics project](https://raw.githubusercontent.com/process-analytics/.github/main/profile/cheat_sheet.png)
 
 
 Our spearhead project is [bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-js/) 🔱, a TypeScript library for visualizing process execution data on [BPMN diagrams](https://www.bpmn.org/). It comes with its companion [examples](https://github.com/process-analytics/bpmn-visualization-examples/) repository ✨.


### PR DESCRIPTION
Quick fix: use full url to images in the master branches

covers #6 