### PR TITLE
[FEAT] Remove Hacktoberfest paragraph from profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -36,12 +36,3 @@ Our cornerstone project is [bpmn-visualization](https://github.com/process-analy
 R users 📈 will be interested in [bpmn-visualization-R](https://github.com/process-analytics/bpmn-visualization-R/), the R package for visualizing process execution data on BPMN diagrams, using overlays, style customization and interactions.
 
 If you are more into design 🎨 and project content 📜, check the [Process Analytics website](https://github.com/process-analytics/process-analytics.dev/) repository. 💕
-
-
-### 🍿 Be ready for Hacktoberfest 2021
-
-Interested in contributing as part of [Hacktoberfest](https://hacktoberfest.digitalocean.com/) ? 💡 The following BPMN diagram explains the participation process at a glance.
-
-[![Hacktoberfest participation BPMN process rendered by bpmn-visualization](https://github.com/process-analytics/bpmn-visualization-examples/raw/a64e681763923c4161b774326936afdebc367c18/examples_home_for_hacktoberfest.png)](https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/v0.19.2/demo/hacktoberfest-custom-themes/index.html)
-
-Want to use the same kind of image to call for Hacktoberfest contributions in your own project or access to light and dark themes? ⏩ Just click on the image to access to a live demo. You will be able to display the name you want within the diagram!


### PR DESCRIPTION
Hacktoberfest 2021 is now over, so there is no need to advertise the event anymore.