### PR TITLE
ci: add a default release-drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,49 @@
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+prerelease: false
+categories:
+  - title: 🚀 Improvements
+    labels:
+      - enhancement
+  - title: 🐛 Bug Fixes
+    labels:
+      - bug
+  - title: 📝 Documentation
+    labels:
+      - documentation
+  - title: 📦 Dependency updates
+    labels:
+      - dependencies
+  - title: 👻 Maintenance
+    labels:
+      - chore
+      - refactoring
+exclude-labels:
+  - skip-changelog
+# Exclude specific usernames from the generated $CONTRIBUTORS variable.
+# https://github.com/release-drafter/release-drafter/tree/master#exclude-contributors
+exclude-contributors:
+  - 'dependabot'
+  - 'dependabot[bot]'
+template: |
+  **TODO: add a short description about the release content - important for url preview**
+  This new release focuses on .... **or something similar**
+  This new version brings improvements to ...
+
+  **TODO: review the contributors list (remove ALL bots and avoid duplicates)**
+  Thanks to all the contributors of this release 🌈: $CONTRIBUTORS
+
+  **TODO: use the right milestone id and ensure the version is the right one**
+  See [milestone $NEXT_PATCH_VERSION](https://github.com/$OWNER/$REPOSITORY/milestone/x?closed=1) to get the list of issues covered by this release.
+
+  **TODO: check previous and next tag in the "full changelog" link in the "What's changed section"**
+
+  # Highlights
+
+  **TODO: add screenshots and user oriented info**
+
+  # What's Changed
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$NEXT_PATCH_VERSION
+
+  $CHANGES

--- a/.github/workflows/pr-metadata-checks.yml
+++ b/.github/workflows/pr-metadata-checks.yml
@@ -1,0 +1,16 @@
+name: Check Pull Request Metadata
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+jobs:
+  pr-enforce-conventional-commits:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check pull request title
+        uses: jef/conventional-commits-pr-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment: false # Post a comment in the pull request conversation with examples.


### PR DESCRIPTION
If there is no release-drafter configuration file in a repository, the file in
the `.github` repository will be used.

In addition, introduce a new GitHub workflow to ensure that the PR titles match
conventional commits.

### Notes

See the documentation of the [release-drafter shared configuration](https://github.com/release-drafter/release-drafter#configuration-options):
> Release Drafter also supports [[Probot Config](https://github.com/probot/probot-config)](https://github.com/probot/probot-config),
 if you want to store your configuration files in a central repository. 
This allows you to share configurations between projects, and create a 
organization-wide configuration file by creating a repository named `.github` with the file `.github/release-drafter.yml`.