### PR TITLE
ci(release-drafter): exclude `process-analytics-bot`

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,6 +25,7 @@ exclude-labels:
 exclude-contributors:
   - 'dependabot'
   - 'dependabot[bot]'
+  - process-analytics-bot
 template: |
   **TODO: add a short description about the release content - important for url preview**
   This new release focuses on .... **or something similar**


### PR DESCRIPTION
The project bot is excluded from the $CONTRIBUTORS variable to avoid manual edits of the release notes.