### PR TITLE
ci(pr-title): use a new shared action

### DIFF
--- a/.github/workflows/pr-metadata-checks.yml
+++ b/.github/workflows/pr-metadata-checks.yml
@@ -1,16 +1,14 @@
 name: Check Pull Request Metadata
 on:
-  pull_request:
-    types:
-      - opened
-      - edited
-      - reopened
+  pull_request_target:
+    # trigger when the PR title changes
+    types: [opened, edited, reopened]
+
 jobs:
-  pr-enforce-conventional-commits:
+  pr-title:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
     steps:
-      - name: Check pull request title
-        uses: jef/conventional-commits-pr-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          comment: false # Post a comment in the pull request conversation with examples.
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2


### PR DESCRIPTION
Switch from `jef/conventional-commits-pr-action` to `bonitasoft/actions`. It provides better defaults and more features. Also run the workflow on `pull_request_target` to ensure that PR created from fork repositories.